### PR TITLE
feat: add size column, select all header and presets

### DIFF
--- a/.tmp/auth_info.json
+++ b/.tmp/auth_info.json
@@ -1,0 +1,1 @@
+{"nlConnectToken":"MJPm8TmJTLiay5gOij9jSuzYLaFvpbkIoKPvi5RxNeQpMEZmR","nlPort":51578,"nlToken":"7VacICWfQtgTzLFyPf61NnTb9rBsNkI-z7TqQss3hfvHpjZ.MJPm8TmJTLiay5gOij9jSuzYLaFvpbkIoKPvi5RxNeQpMEZmR"}

--- a/.tmp/window_state.config.json
+++ b/.tmp/window_state.config.json
@@ -1,1 +1,1 @@
-{"height":500,"maxHeight":-1,"maxWidth":-1,"maximize":false,"minHeight":200,"minWidth":400,"resizable":true,"width":1052,"x":560,"y":290}
+{"height":500,"maxHeight":-1,"maxWidth":-1,"maximize":false,"minHeight":200,"minWidth":400,"resizable":true,"width":1052,"x":293,"y":369}

--- a/resources/index.html
+++ b/resources/index.html
@@ -32,6 +32,11 @@
     </div>
 
     <div class="row">
+      <select id="selPreset" class="m-0"></select>
+      <button id="btnSavePreset" class="icon-btn">Сохранить пресет</button>
+    </div>
+
+    <div class="row">
       <button id="btnPreview">Предпросмотр</button>
       <button id="btnCopyAll">Копировать всё (robocopy /MIR)</button>
       <button id="btnCopySel">Копировать отмеченные</button>
@@ -41,15 +46,15 @@
     <div class="row">
       <label><input id="chkShowExtra" type="checkbox" checked /> показывать «лишние» (OnlyInDst)</label>
       <label><input id="chkShowOlder" type="checkbox" /> показывать «Older»</label>
-      <label><input id="chkSelectAll" type="checkbox" checked /> выделить всё</label>
     </div>
 
     <table id="tbl" class="striped">
       <thead>
         <tr>
-          <th style="width:28px"></th>
+          <th style="width:28px"><input id="chkSelectAll" type="checkbox" checked /></th>
           <th style="width:120px">Статус</th>
           <th>Путь</th>
+          <th style="width:80px">Размер, КБ</th>
         </tr>
       </thead>
       <tbody id="tbody"></tbody>

--- a/resources/index.html
+++ b/resources/index.html
@@ -54,7 +54,7 @@
           <th style="width:28px"><input id="chkSelectAll" type="checkbox" checked /></th>
           <th style="width:120px">Статус</th>
           <th>Путь</th>
-          <th style="width:80px">Размер, КБ</th>
+          <th style="width:80px">Размер</th>
         </tr>
       </thead>
       <tbody id="tbody"></tbody>

--- a/resources/index.html
+++ b/resources/index.html
@@ -54,7 +54,7 @@
           <th style="width:28px"><input id="chkSelectAll" type="checkbox" checked /></th>
           <th style="width:120px">Статус</th>
           <th>Путь</th>
-          <th style="width:80px">Размер</th>
+          <th style="width:100px">Размер</th>
         </tr>
       </thead>
       <tbody id="tbody"></tbody>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -11,6 +11,7 @@ Neutralino.init();
 Neutralino.events.on("ready", async () => {
   loadSession();
   await loadSettings();
+  await loadPresets();
 });
 
 const els = {
@@ -29,13 +30,16 @@ const els = {
   chkShowExtra: document.getElementById('chkShowExtra'),
   chkShowOlder: document.getElementById('chkShowOlder'),
   chkSelectAll: document.getElementById('chkSelectAll'),
+  selPreset: document.getElementById('selPreset'),
+  btnSavePreset: document.getElementById('btnSavePreset'),
   tbody: document.getElementById('tbody'),
   log: document.getElementById('log'),
   hint: document.getElementById('hint')
 };
 
-let rows = []; // [{status, rel, abs, from:'src'|'dst', selected}]
+let rows = []; // [{status, rel, abs, size, from:'src'|'dst', selected}]
 let settings = { ignore: '' };
+let presets = [];
 
 els.btnPreview.onclick = preview;
 els.btnCopyAll.onclick = copyAll;
@@ -43,6 +47,14 @@ els.btnCopySel.onclick = copySelected;
 els.chkSelectAll.onchange = () => setAllSelected(els.chkSelectAll.checked);
 els.chkShowExtra.onchange = renderTable;
 els.chkShowOlder.onchange = renderTable;
+els.btnSavePreset.onclick = savePreset;
+els.selPreset.onchange = () => {
+  const i = parseInt(els.selPreset.value, 10);
+  if (!isNaN(i) && presets[i]) {
+    els.src.value = presets[i].src;
+    els.dst.value = presets[i].dst;
+  }
+};
 els.btnExit.onclick = () => Neutralino.app.exit();
 els.btnSettings.onclick = () => {
   els.txtIgnore.value = settings.ignore;
@@ -80,7 +92,7 @@ async function preview() {
   console.log(r.stdOut);
   const lines = r.stdOut.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
 
-  rows = parseRobocopy(lines, src, dst).filter(x => !isExcluded(x.rel, excl));
+  rows = (await parseRobocopy(lines, src, dst)).filter(x => !isExcluded(x.rel, excl));
   // по умолчанию выделяем только New/Updated
   rows.forEach(x => x.selected = (x.status === 'New' || x.status === 'Updated'));
   els.chkSelectAll.checked = true;
@@ -88,7 +100,7 @@ async function preview() {
   hint(`Найдено: ${rows.length}. Отмечены к копированию: ${rows.filter(x=>x.selected).length}`);
 }
 
-function parseRobocopy(lines, src, dst) {
+async function parseRobocopy(lines, src, dst) {
   // Примеры строк:
   // "New File          C:\src\path\file.txt"
   // "Newer             C:\src\path\file.txt"
@@ -117,6 +129,14 @@ function parseRobocopy(lines, src, dst) {
       out.push({ status: 'Older', rel, abs: full, from: 'src', selected: false });
     }
   }
+  await Promise.all(out.map(async r => {
+    try {
+      const st = await Neutralino.filesystem.getStats(r.abs);
+      r.size = st.size;
+    } catch {
+      r.size = 0;
+    }
+  }));
   return out.sort((a,b) => (a.status+b.rel).localeCompare(b.status+b.rel));
 }
 
@@ -147,9 +167,14 @@ function renderTable() {
     const tdPath = document.createElement('td');
     tdPath.textContent = r.rel;
 
+    const tdSize = document.createElement('td');
+    tdSize.className = 'text-right';
+    tdSize.textContent = Math.round(r.size / 1024);
+
     tr.appendChild(tdSel);
     tr.appendChild(tdStatus);
     tr.appendChild(tdPath);
+    tr.appendChild(tdSize);
     els.tbody.appendChild(tr);
   }
 }
@@ -253,4 +278,34 @@ async function saveSettings(){
   try{
     await Neutralino.storage.setData('robogui_settings', JSON.stringify(settings));
   }catch{}
+}
+
+async function loadPresets(){
+  try{
+    const s = await Neutralino.storage.getData('robogui_presets');
+    if(s) presets = JSON.parse(s);
+  }catch{}
+  renderPresets();
+}
+
+async function savePreset(){
+  const src = norm(els.src.value);
+  const dst = norm(els.dst.value);
+  if(!src || !dst) return toast("Укажи SRC и DST 💛");
+  presets.push({src,dst});
+  try{
+    await Neutralino.storage.setData('robogui_presets', JSON.stringify(presets));
+  }catch{}
+  renderPresets();
+  toast('Пресет сохранён ✨');
+}
+
+function renderPresets(){
+  els.selPreset.innerHTML = '<option value="">-- пресеты --</option>';
+  presets.forEach((p,i) => {
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = `${p.src} ➜ ${p.dst}`;
+    els.selPreset.appendChild(opt);
+  });
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -163,7 +163,7 @@ function renderTable() {
 
     const tdSize = document.createElement('td');
     tdSize.className = 'text-right';
-    tdSize.textContent = Math.round(r.size / 1024);
+    tdSize.textContent = formatKB(r.size);
 
     tr.appendChild(tdSel);
     tr.appendChild(tdStatus);
@@ -220,6 +220,9 @@ async function copySelected() {
 function setAllSelected(v){ rows.forEach(r => r.selected = v); renderTable(); }
 
 // ===== Helpers =====
+function formatKB(bytes){
+  return (bytes / 1024).toFixed(2).replace('.', ',') + ' Кб';
+}
 function norm(p){ return (p || '').replace(/\//g, '\\').replace(/[\\]+$/,''); }
 function winPath(p){ return p.replace(/\//g,'\\'); }
 function join(a,b){ return a.replace(/[\\\/]+$/,'') + '\\' + b.replace(/^[\\\/]+/,''); }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -221,7 +221,7 @@ function setAllSelected(v){ rows.forEach(r => r.selected = v); renderTable(); }
 
 // ===== Helpers =====
 function formatKB(bytes){
-  return (bytes / 1024).toFixed(2).replace('.', ',') + ' Кб';
+  return (bytes / 1024).toFixed(2) + ' Кб';
 }
 function norm(p){ return (p || '').replace(/\//g, '\\').replace(/[\\]+$/,''); }
 function winPath(p){ return p.replace(/\//g,'\\'); }


### PR DESCRIPTION
## Summary
- show file sizes in KB in table
- add select-all checkbox in table header
- allow saving and restoring SRC/DST presets

## Testing
- `npm test`
- `node --check resources/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbb49ea158832ebe0be1e756f200f4