### PR TITLE
feat: manage ignore lists separately

### DIFF
--- a/.tmp/auth_info.json
+++ b/.tmp/auth_info.json
@@ -1,1 +1,1 @@
-{"nlConnectToken":"MJPm8TmJTLiay5gOij9jSuzYLaFvpbkIoKPvi5RxNeQpMEZmR","nlPort":51578,"nlToken":"7VacICWfQtgTzLFyPf61NnTb9rBsNkI-z7TqQss3hfvHpjZ.MJPm8TmJTLiay5gOij9jSuzYLaFvpbkIoKPvi5RxNeQpMEZmR"}
+{"nlConnectToken":"m6-7XGAudEPkLZTX2DpsD6Z2UBmn1nCEYQ2kwlrlKQaRahIjd","nlPort":61829,"nlToken":"PbpDbW8r5Mq59lpg0ft6nrkFgqZOltOIua9ufz6E9a2A_Ny.m6-7XGAudEPkLZTX2DpsD6Z2UBmn1nCEYQ2kwlrlKQaRahIjd"}

--- a/.tmp/window_state.config.json
+++ b/.tmp/window_state.config.json
@@ -1,1 +1,1 @@
-{"height":500,"maxHeight":-1,"maxWidth":-1,"maximize":false,"minHeight":200,"minWidth":400,"resizable":true,"width":1052,"x":293,"y":369}
+{"height":500,"maxHeight":-1,"maxWidth":-1,"maximize":false,"minHeight":200,"minWidth":400,"resizable":true,"width":800,"x":560,"y":290}

--- a/neutralino.config.json
+++ b/neutralino.config.json
@@ -19,7 +19,8 @@
     "debug.log",
     "os.execCommand",
     "filesystem.*",
-    "window.*"
+    "window.*",
+    "storage.*"
   ],
   "globalVariables": {
     "TEST1": "Hello",

--- a/resources/index.html
+++ b/resources/index.html
@@ -14,7 +14,7 @@
       <h3 class="col-8">Syncer — менеджер синхронизации файлов и папок</h3>
       <div class="col-2 text-right">
         <button id="btnSettings" title="Настройки"><span class="material-icons">settings</span></button>
-        <button id="btnExit" title="Выход"><span class="material-icons">logout</span></button>
+        <button id="btnExit" title="Закрыть" class="secondary"><span class="material-icons">close</span></button>
       </div>
     </div>
 

--- a/resources/index.html
+++ b/resources/index.html
@@ -64,8 +64,18 @@
   </main>
   <dialog id="dlgSettings">
     <h3>Настройки</h3>
-    <label>Игнорируемые файлы и папки (через запятую):</label>
-    <input id="txtIgnore" type="text" placeholder="package-lock.json,yarn.lock,.husky" />
+    <label>Игнорируемые файлы:</label>
+    <div id="lstIgnoreFiles" class="ignore-list"></div>
+    <div class="row">
+      <input id="txtIgnoreFile" type="text" placeholder="package-lock.json" class="m-0" />
+      <button id="btnAddIgnoreFile" class="icon-btn"><span class="material-icons">add</span></button>
+    </div>
+    <label>Игнорируемые папки:</label>
+    <div id="lstIgnoreDirs" class="ignore-list"></div>
+    <div class="row">
+      <input id="txtIgnoreDir" type="text" placeholder="node_modules" class="m-0" />
+      <button id="btnAddIgnoreDir" class="icon-btn"><span class="material-icons">add</span></button>
+    </div>
     <menu>
       <button id="btnSaveSettings" class="primary">Сохранить</button>
       <button onclick="this.closest('dialog').close()">Закрыть</button>

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -90,3 +90,7 @@ html {
 
 .muted { color: var(--muted-color); }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+
+.ignore-list .row {
+    margin-bottom: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- split ignored items into file and folder lists with add/remove UI
- persist ignore lists in settings storage and apply to robocopy via /XF and /XD
- minor styling for ignore list items

## Testing
- `node -c resources/js/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc4fded8c832ebd2524b84e62399a