### PR TITLE
Add theme toggle and improve logging

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -12,7 +12,8 @@
   <main class="container">
     <div class="row">
       <h3 class="col-8">Syncer — менеджер синхронизации файлов и папок</h3>
-      <div class="col-2 text-right">
+      <div class="col-3 text-right">
+        <button id="btnTheme" title="Сменить тему"><span class="material-icons">dark_mode</span></button>
         <button id="btnSettings" title="Настройки"><span class="material-icons">settings</span></button>
         <button id="btnExit" title="Закрыть" class="contrast"><span class="material-icons">close</span></button>
       </div>


### PR DESCRIPTION
## Summary
- log human-friendly messages during selective copy operations
- define toast helper to show message boxes
- add light/dark theme toggle stored in Neutralino storage

## Testing
- `node --check resources/js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_68bbd44b0dbc832ea2a6c346204df49c