### PR TITLE
feat: show old and new file sizes

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -57,7 +57,8 @@
           <th style="width:28px"><input id="chkSelectAll" type="checkbox" checked /></th>
           <th style="width:120px">Статус</th>
           <th>Путь</th>
-          <th style="width:100px">Размер</th>
+          <th style="width:100px">Старый размер</th>
+          <th style="width:100px">Новый размер</th>
         </tr>
       </thead>
       <tbody id="tbody"></tbody>


### PR DESCRIPTION
## Summary
- show old and new file sizes for each file in diff
- display two size columns in results table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbda7f1b48832ea2e9f1c464e83015