### PR TITLE
Show separate SRC and DST sizes

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -57,7 +57,8 @@
           <th style="width:28px"><input id="chkSelectAll" type="checkbox" checked /></th>
           <th style="width:120px">Статус</th>
           <th>Путь</th>
-          <th style="width:100px">Размер</th>
+          <th style="width:100px">Размер SRC</th>
+          <th style="width:100px">Размер DST</th>
         </tr>
       </thead>
       <tbody id="tbody"></tbody>


### PR DESCRIPTION
## Summary
- split size column into separate SRC and DST columns
- compute and display file sizes for source and destination

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c170778630832e9aa5d32b1b06a97e