### PR TITLE
Color SRC size column based on DST comparison

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -188,6 +188,11 @@ function renderTable() {
     const tdSizeSrc = document.createElement('td');
     tdSizeSrc.className = 'text-right';
     tdSizeSrc.textContent = formatKB(r.sizeSrc);
+    if (r.sizeSrc > r.sizeDst) {
+      tdSizeSrc.style.color = 'green';
+    } else if (r.sizeSrc < r.sizeDst) {
+      tdSizeSrc.style.color = 'red';
+    }
 
     const tdSizeDst = document.createElement('td');
     tdSizeDst.className = 'text-right';


### PR DESCRIPTION
## Summary
- highlight SRC size in green when larger than DST, red when smaller

## Testing
- `neu run` *(fails: command not found: neu)*

------
https://chatgpt.com/codex/tasks/task_e_68c1734ce7a4832e9aa289c61fef3eb3